### PR TITLE
Hide api key

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -15,7 +15,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     lintOptions {
         disable 'InvalidPackage'
@@ -25,7 +25,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.moviesstreams"
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.2.1'
     }
 }
 

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/lib/api/api_key.dart
+++ b/lib/api/api_key.dart
@@ -1,0 +1,6 @@
+const String myTmdbApiKey = 'put your api key here';
+
+// the api read access token is not required for this app to run.
+// I am including it anyway because it is delivered together with the key
+// and might be of use later on.
+const String myTmdbApiReadAccessToken ='put the api read acces token here';

--- a/lib/api/tmdb_api.dart
+++ b/lib/api/tmdb_api.dart
@@ -1,7 +1,10 @@
+
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:movies_streams/api/tmdb_api_key.dart';
 import 'package:movies_streams/models/movie_genres_list.dart';
 import 'package:movies_streams/models/movie_page_result.dart';
 
@@ -12,7 +15,6 @@ import 'package:movies_streams/models/movie_page_result.dart';
 /// 
 
 class TmdbApi {
-  static const String TMDB_API_KEY = "PUT YOUR KEY, HERE";
   static const String baseUrl = 'api.themoviedb.org';
   final String imageBaseUrl = 'http://image.tmdb.org/t/p/w185/';
   final _httpClient = new HttpClient();
@@ -29,7 +31,7 @@ class TmdbApi {
       baseUrl,
       '3/discover/$type',
       <String, String>{
-        'api_key': TMDB_API_KEY,
+        'api_key': tmdbApiKey,
         'language': 'en-US',
         'sort_by': 'popularity.desc',
         'include_adult': 'false',
@@ -58,7 +60,7 @@ class TmdbApi {
       baseUrl,
       '3/genre/$type/list',
       <String, String>{
-        'api_key': TMDB_API_KEY,
+        'api_key': tmdbApiKey,
         'language': 'en-US',
       },
     );

--- a/lib/api/tmdb_api_key.dart
+++ b/lib/api/tmdb_api_key.dart
@@ -1,6 +1,6 @@
 // If you a hosting a fork of the app repository on any public server 
-// you are advised to remove this file from the repository after 
-// adding the secret key.
+// you are advised to remove this file from the repository before 
+// adding the secret api key.
 // to do this run:
 //     git rm --cached lib/api/tmdb_api_key.dart
 //     git commit -m 'removed secret api key from repository' -o lib/api/tmdb_api_key.dart

--- a/lib/api/tmdb_api_key.dart
+++ b/lib/api/tmdb_api_key.dart
@@ -1,6 +1,6 @@
-const String myTmdbApiKey = 'put your api key here';
+const String tmdbApiKey = 'put your api key here';
 
 // the api read access token is not required for this app to run.
 // I am including it anyway because it is delivered together with the key
 // and might be of use later on.
-const String myTmdbApiReadAccessToken ='put the api read acces token here';
+const String tmdbApiReadAccessToken ='put the api read acces token here';

--- a/lib/api/tmdb_api_key.dart
+++ b/lib/api/tmdb_api_key.dart
@@ -1,3 +1,10 @@
+// If you a hosting a fork of the app repository on any public server 
+// you are advised to remove this file from the repository after 
+// adding the secret key.
+// to do this run:
+//     git rm --cached lib/api/tmdb_api_key.dart
+//     git commit -m 'removed secret api key from repository' -o lib/api/tmdb_api_key.dart
+
 const String tmdbApiKey = 'put your api key here';
 
 // the api read access token is not required for this app to run.


### PR DESCRIPTION
Here is a small modification that helps to hide the api key when forking the repository.


And oops I upgraded gradle and the build sdk to make the app compile on my machine. 
I am afraid I don't know how to exclude that from the pull request without too much fiddling. Just ingnore those changes if not helpful.